### PR TITLE
Fix File Migrator issue when comma in built-in fields

### DIFF
--- a/lib/AdministrativeFunctions/FileAddFieldData.rb
+++ b/lib/AdministrativeFunctions/FileAddFieldData.rb
@@ -122,7 +122,9 @@ module FileAddFieldData
 
                   op = RestOptions.new
                   op.add_option('limit',1)
-                  op.add_option('name',current_value)
+                  # the square bracket in "name[]" is to make sure that even if there's a ',' in the value
+                  #     it doesn't get interpreted as an array.
+                  op.add_option('name[]', current_value)
                   op.add_option('textMatching','exact')
 
                   if rest_code == 'copyright_holder_id'


### PR DESCRIPTION
Built-in fields being "Copyright Holder" and "Photographer". Root cause is due to how our REST API interprets `,`: if GET parameter key is a simple `name`, any `,` forced the entire parameter value to be read as an array, split by `,`. By changing the parameter key to `name[]`, we force the entire parameter value to be read as the first element of the array.