### PR TITLE
2.0.10 - Restricted Field Type Update

### DIFF
--- a/lib/AdministrativeFunctions/ProjectAddFieldData.rb
+++ b/lib/AdministrativeFunctions/ProjectAddFieldData.rb
@@ -99,7 +99,7 @@ module ProjectAddFieldData
             #   working on
             if lookup_string_exists
                 # this is so we have the proper capitalization for the value
-                value = lookup_string_exists
+                value = lookup_string_exists.value
             else
                 data = {:value => value}
                 response = post(lookup_string_endpoint,data,false)

--- a/lib/AdministrativeFunctions/ProjectAddFieldData.rb
+++ b/lib/AdministrativeFunctions/ProjectAddFieldData.rb
@@ -88,12 +88,19 @@ module ProjectAddFieldData
             field_lookup_strings = get(lookup_string_endpoint,nil)
 
             #check if the value in the third argument is currently an available option for the field
-            lookup_string_exists = field_lookup_strings.find { |item| item.value == value }
+            lookup_string_exists = field_lookup_strings.find {
+                |item| item.value.strip.downcase == value.strip.downcase
+            }
 
-            #add the option to the restricted field first if it's not there, otherwise you get a 400 bad
-            #request error saying that it couldn't find the string value for the restricted field specified
-            #when making a PUT request on the PROJECTS resource you are currently working on
-            unless lookup_string_exists
+            # add the option to the restricted field first if it's not there,
+            #   otherwise you get a 400 bad request error saying that it couldn't
+            #   find the string value for the restricted field specified when
+            #   making a PUT request on the PROJECTS resource you are currently
+            #   working on
+            if lookup_string_exists
+                # this is so we have the proper capitalization for the value
+                value = lookup_string_exists
+            else
                 data = {:value => value}
                 response = post(lookup_string_endpoint,data,false)
                 return unless response.kind_of? Net::HTTPSuccess
@@ -164,7 +171,7 @@ module ProjectAddFieldData
                 field_name = current_field.name.downcase.gsub(' ','_')
 
                 unless current_project.instance_variable_defined?('@'+field_name)
-                    warn "ERROR: The specified attirbute \"#{field_name}\" does not" +
+                    warn "ERROR: The specified attribute \"#{field_name}\" does not" +
                          " exist in the Project. Exiting."
                     Thread.exit
                     #exit(-1)

--- a/lib/Version/version.rb
+++ b/lib/Version/version.rb
@@ -1,3 +1,3 @@
 module Openasset
-  VERSION = '2.0.8'.freeze
+  VERSION = '2.0.10'.freeze
 end

--- a/openasset.gemspec
+++ b/openasset.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mime-types", "~> 3.1"
   spec.add_dependency "ruby-progressbar", "~> 1.8"
   spec.add_dependency "colorize", "~> 0.8"
-  
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Fix bug where REST client crashes if it tries to insert a value into a restricted type field (suggestion, fixed suggestion, option) with the same value, but different casing. This is due to the Ruby Client itself checking against true, case sensitive value matches. This causes the Client to think the field value doesn't exist and attempt to create such a value via REST, but this breaks due to OpenAsset's backend checking such values case insensitively.